### PR TITLE
[BIM] Python 3.11.x and above Json Fix for FreeCAD 0.21.2 and above

### DIFF
--- a/archobjects/archview.py
+++ b/archobjects/archview.py
@@ -261,3 +261,9 @@ class ArchView(object):
 
     def __setstate__(self, _state):
         return
+
+    def dumps(self):
+        return
+
+    def loads(self, _state):
+        return

--- a/archobjects/base.py
+++ b/archobjects/base.py
@@ -52,6 +52,12 @@ class ShapeGroup(object):
     def __setstate__(self, _state):
         return
 
+    def dumps(self):
+        return
+
+    def loads(self, _state):
+        return
+    
     def attach(self, obj):
         obj.addExtension("App::GeoFeatureGroupExtensionPython")
 

--- a/archviewproviders/view_archview.py
+++ b/archviewproviders/view_archview.py
@@ -236,6 +236,12 @@ class ViewProviderArchView(object):
     def __setstate__(self, _state):
         return None
 
+    def dumps(self):
+        return None
+
+    def loads(self, _state):
+        return None
+    
     def doubleClicked(self, vobj):
         self.toggle_activate(vobj)
 

--- a/archviewproviders/view_base.py
+++ b/archviewproviders/view_base.py
@@ -161,3 +161,9 @@ class ViewProviderShapeGroup(object):
 
     def __setstate__(self, _state):
         return None
+
+    def dumps(self):
+        return None
+
+    def loads(self, _state):
+        return None


### PR DESCRIPTION
Root Cause is https://github.com/FreeCAD/FreeCAD/commit/fbe2fef

Example error from Sheetmetal Wb:

```
  File "/usr/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
<class 'TypeError'>: Object of type FeaturePython is not JSON serializable
17:04:02  PropertyPythonObject::toString(): failed for <class 'SheetMetalCmd.SMViewProviderFlat'>
17:04:02  pyException: Traceback (most recent call last):
  File "/usr/lib/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
```